### PR TITLE
Add new testimonials to homepage

### DIFF
--- a/src/components/Testimonials.tsx
+++ b/src/components/Testimonials.tsx
@@ -32,6 +32,20 @@ const testimonials = [
     image: "imagenes/test4.jpeg",
     role: "Buzo Master Diver",
     quote: "Los elegiría por la profesionalidad, seriedad y pasión con la que transmiten el buceo. El bonus track es que son excelentes personas y generan un gran ambiente para disfrutar de la actividad"
+  },
+  {
+    id: 5,
+    name: "Cristian Lago",
+    image: "imagenes/test5.png",
+    role: "Buzo Técnico",
+    quote: "Haber logrado \"INTRO TO TECH\" con AP me deja asegurar que los instructores logran de este deporte, el perfecto balance entre aventura, desafío y técnica. El profesionalismo demostrado en todos los cursos y viajes, hace que sea la escuela que elijo para la certificación de mis hijos!"
+  },
+  {
+    id: 6,
+    name: "Sofia Mañan",
+    image: "imagenes/test6.png",
+    role: "Buzo Advanced",
+    quote: "Me contacté con Eduardo y Juan hace más de un año con la intención de aprender a bucear. Lo que ellos me dieron y me siguen dando fue inesperado en ese momento. Me cambiaron la manera de viajar, me despertaron una curiosidad por el mar, el placer de estar inmersa y un grupo increíble con el que compartimos el mismo placer. Bucear no es una actividad hoy, sino parte de mi vida."
   }
 ];
 

--- a/src/components/ui/command.tsx
+++ b/src/components/ui/command.tsx
@@ -21,7 +21,7 @@ const Command = React.forwardRef<
 ))
 Command.displayName = CommandPrimitive.displayName
 
-interface CommandDialogProps extends DialogProps {}
+type CommandDialogProps = DialogProps;
 
 const CommandDialog = ({ children, ...props }: CommandDialogProps) => {
   return (

--- a/src/components/ui/textarea.tsx
+++ b/src/components/ui/textarea.tsx
@@ -2,8 +2,8 @@ import * as React from "react"
 
 import { cn } from "@/lib/utils"
 
-export interface TextareaProps
-  extends React.TextareaHTMLAttributes<HTMLTextAreaElement> {}
+export type TextareaProps =
+  React.TextareaHTMLAttributes<HTMLTextAreaElement>;
 
 const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
   ({ className, ...props }, ref) => {


### PR DESCRIPTION
## Summary
- add Cristian Lago and Sofia Mañan testimonials to landing page
- remove testimonial images so only code changes are included
- switch empty interfaces to type aliases to satisfy lint rules

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a8787ba80c832a83bf21f8d70ed510